### PR TITLE
Fix DOCKER_REPO environment variable assigment

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ machine:
     GOPATH_HEAD: "$(echo $GOPATH | cut -d ':' -f 1)"
     GOPATH_BASE: "$GOPATH_HEAD/src/github.com/$CIRCLE_PROJECT_USERNAME"
     GO15VENDOREXPERIMENT: 1
-    DOCKER_REPO: "$(if [ $CIRCLE_PROJECT_USERNAME == 'Securing-DevOps' ]; then echo securingdevops; else echo $DOCKER_USER; fi)"
+    DOCKER_REPO: "$(echo $CIRCLE_PROJECT_USERNAME | awk '{print tolower($0)}' | sed 's/[^a-z0-9]//g')"
 
   services:
     - docker


### PR DESCRIPTION
CircleCI builds of repos forked from the original Securing-DevOps/invoicer repo fail because the (project level) DOCKER_USER environment variable isn't set until after the circle.yml environment variables are set and thus the DOCKER_REPO environment variable is left blank.

Assuming the intention is to simply set DOCKER_REPO to be a lowercase, alphanumeric, version of CIRCLE_PROJECT_USERNAME, this commit achieves that

Refer to #8 